### PR TITLE
Use apt instead of dpkg for installing packages

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -690,7 +690,7 @@ Optional:
         if [ $do_install -eq 1 ]; then
             if [ ${#debs[@]} -gt 0 ]; then
                 log "Installing ${#debs[@]} packages"
-                $sudo dpkg -i "${debs[@]}" >$debug_target 2>&1
+                $sudo apt install "${debs[@]/#/./}" >$debug_target 2>&1
             else
                 warn "Did not find any .deb files to install"
             fi


### PR DESCRIPTION
I'm not 100% sure the syntax works out but it might be sensible to use `apt install` instead of `dpkg -i` in order to take into account eventual dependencies.
The `/#/./` will prepend `./` to each element of `debs`, as apt needs the full or relative path.
See also part 2 of: https://www.tecmint.com/install-local-deb-packages-in-debian-ubuntu-linux-mint/