### PR TITLE
Propose fix for not asking for root password

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -34,7 +34,7 @@ doublecheckversion=1
 use_https=1
 
 # Path to sudo command
-sudo=$(command -v sudo)
+sudo=$(command -v sudo -k)
 
 # Path to wget command
 wget=$(command -v wget)


### PR DESCRIPTION
This could be a fix for https://github.com/pimlie/ubuntu-mainline-kernel.sh/issues/20.
The `-k` option invalidates the user's cached credentials and thus prompts for the root password again.