### PR TITLE
Better version sorting

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -388,7 +388,7 @@ load_remote_versions () {
             [[ $use_rc -eq 0 ]] && [[ "$line" =~ -rc ]] && continue
             [[ -n "$2" ]] && [[ ! "$line" =~ $2 ]] && continue
             REMOTE_VERSIONS+=("$line")
-        done < <(grep -oP '^.*?DIR.*?href="\Kv\d+(?:\.\d+){1,2}(?:-rc\d+)?(?=/")' <<<"$remote_html_cache" | perl -pe 's/^v\d+\.\d+(?=-|$)/$&.0/; s/^[^-]*?$/$&-rd1/' | sort -V | perl -pe 's/-rd.*//')
+        done < <(grep -oP '^.*?DIR.*?href="\Kv\d+(?:\.\d+){1,2}(?:-rc\d+)?(?=/")' <<<"$remote_html_cache" | perl -pe 's/^v\d++\.\d++(?!\.)/$&.0/; s/-/~/' | sort -V | perl -pe 's/~/-/')
         unset IFS
     fi
 }

--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -369,7 +369,7 @@ latest_local_version() {
 }
 
 remote_html_cache=""
-version_parse() {
+parse_remote_versions() {
     local line
     while read -r line; do
         if [[ $line =~ DIR.*href=\"(v[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?)(-(rc[[:digit:]]+))?/\" ]]; then
@@ -377,6 +377,7 @@ version_parse() {
             if [[ -z "${BASH_REMATCH[2]}" ]]; then
                 line="$line.0"
             fi
+            # temporarily substitute rc suffix join character for correct version sort
             if [[ -n "${BASH_REMATCH[3]}" ]]; then
                 line="$line~${BASH_REMATCH[4]}"
             fi
@@ -401,6 +402,7 @@ load_remote_versions () {
 
         IFS=$'\n'
         while read -r line; do
+            # reinstate original rc suffix join character
             if [[ $line =~ ^([^~]+)~([^~]+)$ ]]; then
                 [[ $use_rc -eq 0 ]] && continue
                 line="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"

--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -102,7 +102,7 @@ action_data=()
 } || {
     OS=$(lsb_release -si 2>&-)
     [[ "$OS" == "Ubuntu" ]] || [[ "$OS" == "LinuxMint" ]]  || [[ "$OS" == "neon" ]] || {
-        echo "Abort, this script is only intended for Ubuntu-like distro's"
+        echo "Abort, this script is only intended for Ubuntu-like distros"
         exit 2
     }
 }
@@ -342,7 +342,7 @@ load_local_versions() {
     local version
     if [ ${#LOCAL_VERSIONS[@]} -eq 0 ]; then
         IFS=$'\n'
-        for pckg in $(dpkg -l linux-image-* | cut -d " " -f 3 | sort); do
+        for pckg in $(dpkg -l linux-image-* | cut -d " " -f 3 | sort -V); do
             # only match kernels from ppa
             if [[ "$pckg" =~ linux-image-[0-9]+\.[0-9]+\.[0-9]+-[0-9]{6} ]]; then
                 version="v"$(echo "$pckg" | cut -d"-" -f 3,4)
@@ -384,28 +384,18 @@ load_remote_versions () {
         fi
 
         IFS=$'\n'
-        for line in $remote_html_cache; do
-            [[ "$line" =~ "folder" ]] || continue
+        while read -r line; do
             [[ $use_rc -eq 0 ]] && [[ "$line" =~ -rc ]] && continue
-            [[ "$line" =~ v[0-9]+\.[0-9]+(\.[0-9]+)?(-rc[0-9]+)?/ ]] || continue
             [[ -n "$2" ]] && [[ ! "$line" =~ $2 ]] && continue
-
-            line=${line##*href=\"}
-            line=${line%%\/\">*}
-            [[ ! "$line" =~ (v[0-9]+\.[0-9]+)\.[0-9]+ ]] && [[ "$line" =~ (v[0-9]+\.[0-9]+)(-rc[0-9]+)? ]] && line=${BASH_REMATCH[1]}".0"${BASH_REMATCH[2]}
-
             REMOTE_VERSIONS+=("$line")
-        done
+        done < <(grep -oP '^.*?DIR.*?href="\Kv\d+(?:\.\d+){1,2}(?:-rc\d+)?(?=/")' <<<"$remote_html_cache" | perl -pe 's/^v\d+\.\d+(?=-|$)/$&.0/; s/^[^-]*?$/$&-rd1/' | sort -V | perl -pe 's/-rd.*//')
         unset IFS
     fi
 }
 
 latest_remote_version () {
     load_remote_versions 1 "$1"
-    local sorted
-
-    mapfile -t sorted < <(echo "${REMOTE_VERSIONS[*]}" | tr ' ' '\n' | sort -V)
-    echo "${sorted[${#sorted[@]}-1]}"
+    echo "${REMOTE_VERSIONS[${#REMOTE_VERSIONS[@]}-1]}"
 }
 
 check_environment () {

--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -409,7 +409,7 @@ load_remote_versions () {
             fi
             [[ -n "$2" ]] && [[ ! "$line" =~ $2 ]] && continue
             REMOTE_VERSIONS+=("$line")
-        done < <(version_parse | sort -V)
+        done < <(parse_remote_versions | sort -V)
         unset IFS
     fi
 }


### PR DESCRIPTION
Have remote list sorted correctly by default for better readability latest version selection (in case `-rc*` versions are used).

Previous output of `ubuntu-mainline-kernel -r v5.8. --rc`:
```none
Downloading index from kernel.ubuntu.com
v5.8.0-rc1      v5.8.0-rc2      v5.8.0-rc3      v5.8.0-rc4      v5.8.0-rc5      v5.8.0-rc6      v5.8.0-rc7      v5.8.1
v5.8.2          v5.8.3          v5.8.4          v5.8.5          v5.8.6          v5.8.7          v5.8.8          v5.8.9
v5.8.10         v5.8.0
```
Updated output:
```none
Downloading index from kernel.ubuntu.com
v5.8.0-rc1      v5.8.0-rc2      v5.8.0-rc3      v5.8.0-rc4      v5.8.0-rc5      v5.8.0-rc6      v5.8.0-rc7      v5.8.0
v5.8.1          v5.8.2          v5.8.3          v5.8.4          v5.8.5          v5.8.6          v5.8.7          v5.8.8
v5.8.9          v5.8.10
```