### PR TITLE
Fix typo on error message

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -781,7 +781,7 @@ EOF
                 --update=no \
                 --rename=yes \
                 --series="$series"; then
-                err "Error durring build"
+                err "Error during build"
                 exit 1
             fi
 


### PR DESCRIPTION
I noticed it says "Error _durring_ build", the correct spelling of the word is "during"