### PR TITLE
fix #95: report installation errors

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -1009,7 +1009,11 @@ EOF
         if [ $do_install -eq 1 ]; then
             if [ ${#debs[@]} -gt 0 ]; then
                 log "Installing ${#debs[@]} packages"
-                $sudo dpkg -i "${debs[@]}" >$debug_target 2>&1
+                if ! $sudo dpkg -i "${debs[@]}" >$debug_target 2>&1; then
+                    err "Installation failed."
+                    err "Uninstall this kernel and rerun with --debug to see error details."
+                    exit 4
+                fi
             else
                 warn "Did not find any .deb files to install"
             fi


### PR DESCRIPTION
Fix #95:
If installation fails, print error message, suggest that the kernel should be removed, suggest how to find out the details, and exit the script with error code 4.